### PR TITLE
Force postgrest to fetch the count in list request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ export default (apiUrl, httpClient = fetchJson) => {
             const { field, order } = params.sort;
 			options.headers.set('Range-Unit','items');
 			options.headers.set('Range',((page-1)*perPage) + '-' + ((page * perPage) -1)   );
+			options.headers.set('Prefer','count=exact');
 			const pf = params.filter;
 			Object.keys(pf).map(function (b){pf[b]='ilike.' + pf[b].replace(/:/,'') + '%' })
             let query = {

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ export default (apiUrl, httpClient = fetchJson) => {
         const { headers, json } = response;
         switch (type) {
         case GET_LIST:
+        case GET_MANY_REFERENCE:
             if (!headers.has('content-range')) {
                 throw new Error('The Content-Range header is missing in the HTTP Response. The simple REST client expects responses for lists of resources to contain this header with the total number of results to build the pagination. If you are using CORS, did you declare Content-Range in the Access-Control-Expose-Headers header?');
             }
@@ -113,7 +114,7 @@ export default (apiUrl, httpClient = fetchJson) => {
         case UPDATE:
             return { ...params.data, id: params.id };
         default:
-            return json;
+            return { data: json };
         }
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,12 @@ export default (apiUrl, httpClient = fetchJson) => {
         }
         case GET_MANY_REFERENCE: {
             const filters = {};
+            const { field, order } = params.sort;
 			filters[params.target] = params.id;
-			const query = convertFilters(filters);
+            let query = {
+                order: field + '.' +  order.toLowerCase(),
+            };
+			Object.assign(query, convertFilters(filters));
             url = `${apiUrl}/${resource}?${queryParameters(query)}`;
             break;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,9 @@ export default (apiUrl, httpClient = fetchJson) => {
 			options.headers.set('Range',((page-1)*perPage) + '-' + ((page * perPage) -1)   );
 			options.headers.set('Prefer','count=exact');
 			const pf = params.filter;
-			Object.keys(pf).map(function (b){pf[b]='ilike.' + pf[b].replace(/:/,'') + '%' })
+			Object.keys(pf).map(function (b) {
+				pf[b]='ilike.%' + pf[b].replace(/:/,'') + '%'
+			})
             let query = {
                 order: field + '.' +  order.toLowerCase(),
             };


### PR DESCRIPTION
Since postgrest 4.0, the count is not fetched by default.
So in order to keep page working, we need to force postgrest
to get the count.