### PR TITLE
allow filter on json/jsonb datatype

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,12 @@ export default (apiUrl, httpClient = fetchJson) => {
                     rest[key]='eq.' + filters[key];
                     break;
 
+                case 'object':
+                    Object.keys(filters[key]).map( (val) => (
+                      rest[`${key}->>${val}`]=`ilike.*${filters[key][val]}*`
+                    ));
+                    break;
+
                 default:
                     rest[key]='ilike.*' + filters[key].toString().replace(/:/,'') + '*';
                     break;


### PR DESCRIPTION
Postgres handle json/jsonb datatype, which can be helpful in some situations, as a prototype in my case.

For example:
`
CREATE TABLE school (
  id SERIAL PRIMARY KEY,
  data JSONB
);  
`

I was trying to filter on `data` and found out that the way to it on postgrest is this one:

`http://localhost:3000/school?data->>name=ilike.*goku*`

if you are looking for a `school` that its `name` key on his `data` json/jsonb is similiar to 'goku'.

example of data:
```json
{
  name: "Goku's School ",
  assistant: "Vegeta",
  years: "23"
}
```

Couldn't filter on my `data` column until I started looking the code and realized it was missing.

So I think I found a way to fix this, that also supports add many filters on the same `data` attribute.
example:

looking for school that its name is similar to 'ku' and its assistant 've':
`school?data->>name=ilike.*goku*&data->>assistant=ilike.*ve*`

Hope it works and can help someone else.