### PR TITLE
Enclose GET_MANY 'in' params in parentheses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var _reactAdmin = require('react-admin');
  *              => GET http://my.api.url/posts/2
  * GET_LIST     => GET http://my.api.url/posts?order=title.asc
  * GET_ONE      => GET http://my.api.url/posts?id=eq.123
- * GET_MANY     => GET http://my.api.url/posts?id=in.123,456,789
+ * GET_MANY     => GET http://my.api.url/posts?id=in.(123,456,789)
  * UPDATE       => PATCH http://my.api.url/posts?id=eq.123
  * CREATE       => POST http://my.api.url/posts
  * DELETE       => DELETE http://my.api.url/posts?id=eq.123

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,9 +50,13 @@ exports.default = function (apiUrl) {
                     break;
 
                 case 'object':
-                    Object.keys(filters[key]).map(function (val) {
-                        return rest[key + '->>' + val] = 'ilike.*' + filters[key][val] + '*';
-                    });
+                    if (filters[key].constructor === Array) {
+                        rest[key] = 'cs.{' + filters[key].toString().replace(/:/, '') + '}';
+                    } else {
+                        Object.keys(filters[key]).map(function (val) {
+                            return rest[key + '->>' + val] = 'ilike.*' + filters[key][val] + '*';
+                        });
+                    }
                     break;
 
                 default:
@@ -102,7 +106,7 @@ exports.default = function (apiUrl) {
                 }
             case _reactAdmin.GET_MANY:
                 {
-                    url = apiUrl + '/' + resource + '?id=in.' + params.ids.join(',');
+                    url = apiUrl + '/' + resource + '?id=in.(' + params.ids.join(',') + ')';
                     break;
                 }
             case _reactAdmin.GET_MANY_REFERENCE:

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import {
  *              => GET http://my.api.url/posts/2
  * GET_LIST     => GET http://my.api.url/posts?order=title.asc
  * GET_ONE      => GET http://my.api.url/posts?id=eq.123
- * GET_MANY     => GET http://my.api.url/posts?id=in.123,456,789
+ * GET_MANY     => GET http://my.api.url/posts?id=in.(123,456,789)
  * UPDATE       => PATCH http://my.api.url/posts?id=eq.123
  * CREATE       => POST http://my.api.url/posts
  * DELETE       => DELETE http://my.api.url/posts?id=eq.123

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export default (apiUrl, httpClient = fetchJson) => {
             break;
         }
         case GET_MANY: {
-            url = `${apiUrl}/${resource}?id=in.${params.ids.join(',')}`;
+            url = `${apiUrl}/${resource}?id=in.(${params.ids.join(',')})`;
             break;
         }
         case GET_MANY_REFERENCE: {


### PR DESCRIPTION
Hi! I'm new to this project, really useful, thanks.

It seems like as per [postgREST docs](http://postgrest.org/en/v5.1/api.html#horizontal-filtering-rows), GET_MANY requests require the parameter list in the query string to be sent in parentheses:

`one of a list of values e.g. ?a=in.(1,2,3)`

The current version of `aor-postgrest-client` omits the parentheses. Without them, the current version of postgREST (v5.1) returns HTTP 400 Bad Request. So this commit patches the URL to include the parentheses. Tested & working on my `react-admin` prototype app.

Wasn't sure whether to include the build artifact, but it's in the existing repo so I built and committed `lib/index.js` as well as `src/index.js`.